### PR TITLE
fix windows issue "Expected linebreaks to be 'LF' but found 'CRLF' li…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "monaco": true
   },
   "rules": {
+    "linebreak-style": 0,
     "prettier/prettier": [
       "error",
       {


### PR DESCRIPTION
…nebreak-style in Eslint using gulp"